### PR TITLE
Saa716x 4.16 random fixes (2)

### DIFF
--- a/drivers/media/common/saa716x/Kconfig
+++ b/drivers/media/common/saa716x/Kconfig
@@ -17,6 +17,10 @@ config SAA716X_CORE
 config DVB_SAA716X_BUDGET
 	tristate "SAA7160/1/2 based Budget PCIe cards (DVB only)"
 	depends on SAA716X_CORE && DVB_CORE
+	select DVB_MB86A16 if MEDIA_SUBDRV_AUTOSELECT
+	select DVB_STV6110x if MEDIA_SUBDRV_AUTOSELECT
+	select DVB_STV090x if MEDIA_SUBDRV_AUTOSELECT
+
 
 	help
 	  Support for the SAA7160/1/2 based Budget PCIe DVB cards
@@ -32,6 +36,10 @@ config DVB_SAA716X_BUDGET
 config DVB_SAA716X_HYBRID
 	tristate "SAA7160/1/2 based Hybrid PCIe cards (DVB + Analog)"
 	depends on SAA716X_CORE && DVB_CORE
+	select DVB_ZL10353 if MEDIA_SUBDRV_AUTOSELECT
+	select DVB_MB86A16 if MEDIA_SUBDRV_AUTOSELECT
+	select DVB_TDA1004X if MEDIA_SUBDRV_AUTOSELECT
+	select MEDIA_TUNER_TDA827X if MEDIA_SUBDRV_AUTOSELECT
 
 	help
 	  Support for the SAA7160/1/2 based Hybrid PCIe DVB cards
@@ -49,6 +57,9 @@ config DVB_SAA716X_FF
 	tristate "SAA7160/1/2 based Full Fledged PCIe cards"
 	depends on SAA716X_CORE && DVB_CORE
 	depends on INPUT # IR
+	select DVB_STV6110x if MEDIA_SUBDRV_AUTOSELECT
+	select DVB_STV090x if MEDIA_SUBDRV_AUTOSELECT
+	select DVB_ISL6423 if MEDIA_SUBDRV_AUTOSELECT
 
 	help
 	  Support for the SAA7160/1/2 based  Full fledged PCIe DVB cards

--- a/drivers/media/common/saa716x/saa716x_budget.c
+++ b/drivers/media/common/saa716x/saa716x_budget.c
@@ -539,7 +539,7 @@ static int skystar2_express_hd_frontend_attach(struct saa716x_adapter *adapter,
 {
 	struct saa716x_dev *saa716x = adapter->saa716x;
 	struct saa716x_i2c *i2c = &saa716x->i2c[SAA716x_I2C_BUS_B];
-	struct stv6110x_devctl *ctl;
+	const struct stv6110x_devctl *ctl;
 
 	if (count < saa716x->config->adapters) {
 		dprintk(SAA716x_DEBUG, 1, "Adapter (%d) SAA716x frontend Init",
@@ -557,8 +557,7 @@ static int skystar2_express_hd_frontend_attach(struct saa716x_adapter *adapter,
 		saa716x_gpio_write(saa716x, 26, 1);
 		msleep(10);
 
-		adapter->fe = dvb_attach(stv090x_attach,
-					 &skystar2_stv090x_config,
+		adapter->fe = stv090x_attach(&skystar2_stv090x_config,
 					 &i2c->i2c_adapter,
 					 STV090x_DEMODULATOR_0);
 
@@ -572,8 +571,7 @@ static int skystar2_express_hd_frontend_attach(struct saa716x_adapter *adapter,
 		adapter->fe->ops.set_voltage = skystar2_set_voltage;
 		adapter->fe->ops.enable_high_lnb_voltage = skystar2_voltage_boost;
 
-		ctl = dvb_attach(stv6110x_attach,
-				 adapter->fe,
+		ctl = stv6110x_attach(adapter->fe,
 				 &skystar2_stv6110x_config,
 				 &i2c->i2c_adapter);
 

--- a/drivers/media/common/saa716x/saa716x_ff_main.c
+++ b/drivers/media/common/saa716x/saa716x_ff_main.c
@@ -1756,15 +1756,13 @@ static int saa716x_s26400_frontend_attach(struct saa716x_adapter *adapter, int c
 	dprintk(SAA716x_DEBUG, 1, "Adapter (%d) Device ID=%02x", count, saa716x->pdev->subsystem_device);
 
 	if (count == 0 || count == 1) {
-		adapter->fe = dvb_attach(stv090x_attach,
-					 &tt6400_stv090x_config,
+		adapter->fe = stv090x_attach(&tt6400_stv090x_config,
 					 i2c_adapter,
 					 STV090x_DEMODULATOR_0 + count);
 
 		if (adapter->fe) {
-			struct stv6110x_devctl *ctl;
-			ctl = dvb_attach(stv6110x_attach,
-					 adapter->fe,
+			const struct stv6110x_devctl *ctl;
+			ctl = stv6110x_attach(adapter->fe,
 					 &tt6400_stv6110x_config,
 					 i2c_adapter);
 
@@ -1790,8 +1788,7 @@ static int saa716x_s26400_frontend_attach(struct saa716x_adapter *adapter, int c
 					adapter->fe->ops.init(adapter->fe);
 			}
 
-			dvb_attach(isl6423_attach,
-				   adapter->fe,
+			isl6423_attach(adapter->fe,
 				   i2c_adapter,
 				   &tt6400_isl6423_config[count]);
 

--- a/drivers/media/common/saa716x/saa716x_hybrid.c
+++ b/drivers/media/common/saa716x/saa716x_hybrid.c
@@ -483,7 +483,7 @@ static int saa716x_atlantis_frontend_attach(struct saa716x_adapter *adapter,
 			"found TDA10046 DVB-T frontend @0x%02x",
 			tda1004x_atlantis_config.demod_address);
 
-		if (dvb_attach(tda827x_attach, adapter->fe,
+		if (tda827x_attach(adapter->fe,
 			       tda1004x_atlantis_config.tuner_address,
 			       &i2c->i2c_adapter, &tda827x_atlantis_config)) {
 			dprintk(SAA716x_ERROR, 1, "found TDA8275 tuner @0x%02x",
@@ -594,7 +594,7 @@ static int saa716x_nemo_frontend_attach(struct saa716x_adapter *adapter, int cou
 		} else {
 			goto exit;
 		}
-		if (dvb_attach(tda827x_attach, adapter->fe,
+		if (tda827x_attach(adapter->fe,
 			       tda1004x_nemo_config.tuner_address,
 			       &tuner_i2c->i2c_adapter, &tda827x_nemo_config)) {
 			dprintk(SAA716x_ERROR, 1, "found TDA8275 tuner @0x%02x",

--- a/drivers/media/dvb-frontends/stv090x.h
+++ b/drivers/media/dvb-frontends/stv090x.h
@@ -109,7 +109,7 @@ struct stv090x_config {
 
 #if IS_REACHABLE(CONFIG_DVB_STV090x)
 
-struct dvb_frontend *stv090x_attach(struct stv090x_config *config,
+extern struct dvb_frontend *stv090x_attach(struct stv090x_config *config,
 				    struct i2c_adapter *i2c,
 				    enum stv090x_demodulator demod);
 


### PR DESCRIPTION
Two patches:
1.: to fix the driver with "CONFIG_TRIM_UNUSED_KSYMS"
2.: to make sure frontends are available and build

This is mainly for reviewing the patches, they can later be cherry picked and applied to newer branches/version e.g. 4.19 without the need of modifications.
