### PR TITLE
Fix for CONFIG_TRIM_UNUSED_KSYMS

### DIFF
--- a/drivers/media/pci/saa716x/saa716x_adap.c
+++ b/drivers/media/pci/saa716x/saa716x_adap.c
@@ -321,6 +321,11 @@ void saa716x_dvb_exit(struct saa716x_dev *saa716x)
 		pci_dbg(saa716x->pdev, "dvb_unregister_adapter");
 		dvb_unregister_adapter(&saa716x_adap->dvb_adapter);
 
+		if (saa716x_adap->fe_config)
+			kfree(saa716x_adap->fe_config);
+		if (saa716x_adap->ctl_config)
+			kfree(saa716x_adap->ctl_config);
+
 		saa716x_adap++;
 	}
 }

--- a/drivers/media/pci/saa716x/saa716x_priv.h
+++ b/drivers/media/pci/saa716x/saa716x_priv.h
@@ -76,6 +76,9 @@ struct saa716x_adapter {
 
 	struct i2c_client		*i2c_client_demod;
 	struct i2c_client		*i2c_client_tuner;
+
+	void				*fe_config;
+	void				*ctl_config;
 };
 
 struct saa716x_dev {


### PR DESCRIPTION
While with dvb_attach() and the config option CONFIG_TRIM_UNUSED_KSYMS the driver remains non-functional, we can use dvb_module_probe() instead. With the change we can finally use the CONFIG_TRIM_UNUSED_KSYMS.

Prerequisite patches are in media_tree (the maintainers git) and will hopefully pushed to the main repo in the 5.3 cycle:
https://git.linuxtv.org/media_tree.git/commit/?id=eb5005df886b3989dde5378064cc23315f769290
https://git.linuxtv.org/media_tree.git/commit/?id=3c8f4cd271c486844e8eccebaf6714d913180ecc

This is to have it reviewed beforehand.
PS: tested working!
PPS: We theoretically could do this with all frontends, yet i have started with the hardware i use. If you are in favor, i can check the other flavors.